### PR TITLE
passing an empty array to the whereIn/orWhereIn produced a query ignoring …

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1442,7 +1442,13 @@ abstract class Doctrine_Query_Abstract
     {
         // if there's no params, return (else we'll get a WHERE IN (), invalid SQL)
         if (isset($params) and is_array($params) and (count($params) == 0)) {
-            return $this;
+            // If $not == true, the condition can be skipped, but if $not == false
+            // we add an always false condition to prevent an unexpected sql result.
+            if($not) {
+                return $this;
+            } else {
+                return $this->where('1 = 0');
+            }
         }
 
         if ($this->_hasDqlQueryPart('where')) {
@@ -1469,10 +1475,11 @@ abstract class Doctrine_Query_Abstract
      */
     public function orWhereIn($expr, $params = array(), $not = false)
     {
+        // -- no, don't return $this as it generates queries with unexpected behavior. _processWhereIn() does throw an adequate exception!
         // if there's no params, return (else we'll get a WHERE IN (), invalid SQL)
-        if (isset($params) and (count($params) == 0)) {
+        /*if (isset($params) and (count($params) == 0)) {
             return $this;
-        }
+        }*/
 
         if ($this->_hasDqlQueryPart('where')) {
             $this->_addDqlQueryPart('where', 'OR', true);

--- a/tests/Ticket/1558TestCase.php
+++ b/tests/Ticket/1558TestCase.php
@@ -41,9 +41,9 @@ class Doctrine_Ticket_1558_TestCase extends Doctrine_UnitTestCase
                 ->orWhereIn('u.id', array(1))
                 ->orWhereIn('u.id', array(1))
                 ->andWhereIn('u.id', array(1))
-                ->whereIn('u.id', array())
-                ->orWhereIn('u.id', array());
-            $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.id IN (?) OR e.id IN (?) OR e.id IN (?) AND e.id IN (?) AND (e.type = 0))');
+                ->whereIn('u.id', array(1))
+                ->orWhereIn('u.id', array(1));
+            $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.id IN (?) OR e.id IN (?) OR e.id IN (?) AND e.id IN (?) AND e.id IN (?) OR e.id IN (?) AND (e.type = 0))');
             $results = $q->execute();
             $this->pass();
         } catch (Exception $e) {


### PR DESCRIPTION
… the column completely with only one column in the where clause, the query became invalid. The test is not correct at the moment.